### PR TITLE
Fixes for Windows

### DIFF
--- a/src/android/__init__.py
+++ b/src/android/__init__.py
@@ -19,4 +19,4 @@ limitations under the License.
 """
 
 
-__version__ = ('0', '9', '+')
+__version__ = ('0', '10', '+')

--- a/src/android/build.py
+++ b/src/android/build.py
@@ -108,8 +108,8 @@ class PlatformTarget(object):
                 'apkbuilder.bat' if sys.platform=='win32' else 'apkbuilder'),
             zipalign = path.join(sdk_dir, 'tools',
                 'zipalign.exe' if sys.platform=='win32' else 'zipalign'),
-            jarsigner = 'jarsigner',
-            javac = 'javac',
+            jarsigner = 'jarsigner.exe' if sys.platform=='win32' else 'jarsigner',
+            javac = 'javac.exe' if sys.platform=='win32' else 'javac',
         )
 
         if ndk_dir is not None:

--- a/src/android/tools.py
+++ b/src/android/tools.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import sys
 import subprocess
 
 
@@ -71,7 +72,7 @@ class Program(object):
         along to their caller.
         """
         cmdline = " ".join([self.executable] + arguments)
-        process = subprocess.Popen([self.executable] + arguments,
+        process = subprocess.Popen([self.executable] + arguments,shell=True if sys.platform=="win32" else False,
                                    stderr=subprocess.PIPE,
                                    stdout=subprocess.PIPE)
         process.wait()


### PR DESCRIPTION
I managed to correct the error.  The key turned out to be shell=True.  I also had to add the file extension for javac.  I tested this on Windows 7 with Python27 and on an Ubuntu VirtualBox running Python27.
